### PR TITLE
Add ICC2019 deadlines

### DIFF
--- a/conferences.yaml
+++ b/conferences.yaml
@@ -704,6 +704,8 @@ ICC:
       motto: Mapping everything for everyone
       url: http://www.icc2019.org
       proceedings: https://icaci.org/icc2019/
+      deadlineFullPaper: 2018-12-05
+      deadlineShortPaper: 2018-12-19
     ICC 2017:
       count: 28th
       start: 2017-07-02


### PR DESCRIPTION
CfP ICC2019 has been released just now. See http://www.icc2019.org/papers.html