### PR TITLE
Typo AGG -> AAG

### DIFF
--- a/conferences.yaml
+++ b/conferences.yaml
@@ -147,112 +147,112 @@ ACM SIGSPATIAL:
       start: 1993
       end: 1993
       place: Arlington, VA, USA
-AGG Annual Meeting:
+AAG Annual Meeting:
   long name: American Association of Geographers Annual Meeting
   events:
-    AGG Annual Meeting 2019:
+    AAG Annual Meeting 2019:
       count: 115th
       start: 2019-04-03
       end: 2019-04-07
       place: Washington, DC, USA
       url: https://annualmeeting.aag.org
-    AGG Annual Meeting 2018:
+    AAG Annual Meeting 2018:
       count: 114th
       start: 2018-04-10
       end: 2018-04-14
       place: New Orleans, LA, USA
       url: http://app.core-apps.com/aagam2018
-    AGG Annual Meeting 2017:
+    AAG Annual Meeting 2017:
       count: 113th
       start: 2017-04-05
       end: 2017-04-09
       place: Boston, MA, USA
       url: http://app.core-apps.com/aagam2017
-    AGG Annual Meeting 2016:
+    AAG Annual Meeting 2016:
       count: 112th
       start: 2016-03-29
       end: 2016-04-02
       place: San Francisco, CA, USA
       url: http://app.core-apps.com/aagam2016
-    AGG Annual Meeting 2015:
+    AAG Annual Meeting 2015:
       count: 111th
       start: 2015-04-21
       end: 2015-04-25
       place: Chicago, IL, USA
       url: http://app.core-apps.com/aagam2015
-    AGG Annual Meeting 2014:
+    AAG Annual Meeting 2014:
       count: 110th
       start: 2014-04-08
       end: 2014-04-12
       place: Tampa, FL, USA
       url: http://app.core-apps.com/aagam2014
-    AGG Annual Meeting 2013:
+    AAG Annual Meeting 2013:
       count: 109th
       start: 2013-04-09
       end: 2013-04-13
       place: Los Angeles, CA, USA
       url: http://app.core-apps.com/aagam2013
-    AGG Annual Meeting 2012:
+    AAG Annual Meeting 2012:
       count: 108th
       start: 2012-02-24
       end: 2012-02-28
       place: New York, NY, USA
-    AGG Annual Meeting 2011:
+    AAG Annual Meeting 2011:
       count: 107th
       start: 2011-04-12
       end: 2011-04-16
       place: Seattle, WA, USA
-    AGG Annual Meeting 2010:
+    AAG Annual Meeting 2010:
       count: 106th
       start: 2010-04-14
       end: 2010-04-18
       place: Washington, DC, USA
-    AGG Annual Meeting 2009:
+    AAG Annual Meeting 2009:
       count: 105th
       start: 2009-03-22
       end: 2009-03-27
       place: Las Vegas, NV, USA
-    AGG Annual Meeting 2008:
+    AAG Annual Meeting 2008:
       count: 104th
       start: 2008-04-15
       end: 2008-04-19
       place: Boston, MA, USA
-    AGG Annual Meeting 2007:
+    AAG Annual Meeting 2007:
       count: 103rd
       start: 2007-04-17
       end: 2007-04-21
       place: San Francisco, CA, USA
-    AGG Annual Meeting 2006:
+    AAG Annual Meeting 2006:
       count: 102nd
       start: 2006-03-07
       end: 2006-03-11
       place: Chicago, IL, USA
-    AGG Annual Meeting 2005:
+    AAG Annual Meeting 2005:
       count: 101st
       start: 2005-04-05
       end: 2005-04-09
       place: Denver, CO, USA
-    AGG Annual Meeting 2004:
+    AAG Annual Meeting 2004:
       count: 100th
       start: 2004-03-14
       end: 2004-03-19
       place: Philadelphia, PA, USA
-    AGG Annual Meeting 2003:
+    AAG Annual Meeting 2003:
       count: 99th
       start: 2003-03-05
       end: 2003-03-08
       place: New Orleans, LA, USA
-    AGG Annual Meeting 2002:
+    AAG Annual Meeting 2002:
       count: 98th
       start: 2002-03-19
       end: 2002-03-22
       place: Los Angeles, CA, USA
-    AGG Annual Meeting 2001:
+    AAG Annual Meeting 2001:
       count: 97th
       start: 2001-02-27
       end: 2001-03-03
       place: New York, NY, USA
-    AGG Annual Meeting 2000:
+    AAG Annual Meeting 2000:
       count: 96th
       start: 2000-04-04
       end: 2000-04-08


### PR DESCRIPTION
It's actually "AAG Annual Meeting" not "AGG ..."